### PR TITLE
fail gracefully when a query returns no entries to be retrieved

### DIFF
--- a/bacdive/client.py
+++ b/bacdive/client.py
@@ -163,7 +163,7 @@ class BacdiveClient():
     def retrieve(self, filter=None):
         ''' Yields all the received entries and does next call if result is incomplete '''
         ids = ";".join([str(i) for i in self.result['results']])
-        entries = self.do_api_call('fetch/'+ids)['results']
+        entries = self.do_api_call('fetch/'+ids)['results'] if ids else []
         for el in entries:
             if isinstance(el, dict):
                 entry = el


### PR DESCRIPTION
If there are no entries to be retrieved, the dict returned by the API call will not have a `results` key. To avoid a KeyError crash in a client program, I added a check to see if `ids` is empty.